### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -51,7 +51,7 @@ export function configure(ctx: HttpClientHintsContext, nuxt: Nuxt) {
     }
   }
 
-  const clientOnly = nuxt.options._generate || !nuxt.options.ssr
+  const clientOnly = nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ || !nuxt.options.ssr
 
   // we register the client detector only if needed and not in SSR mode
   if ((options.detectBrowser || options.detectOS || resolvedOptions.userAgent.length) && clientOnly) {

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -51,6 +51,7 @@ export function configure(ctx: HttpClientHintsContext, nuxt: Nuxt) {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const clientOnly = nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ || !nuxt.options.ssr
 
   // we register the client detector only if needed and not in SSR mode


### PR DESCRIPTION
### Description


Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
